### PR TITLE
AAC encoder

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -11,7 +11,18 @@ defmodule Membrane.Element.AAC.BundlexProject do
     [
       decoder: [
         deps: [membrane_common_c: :membrane, unifex: :unifex],
-        sources: ["_generated/decoder.c", "decoder.c"],
+        sources: [
+          "_generated/decoder.c",
+          "decoder.c"
+        ],
+        libs: ["fdk-aac"]
+      ],
+      encoder: [
+        deps: [membrane_common_c: :membrane, unifex: :unifex],
+        sources: [
+          "_generated/encoder.c",
+          "encoder.c"
+        ],
         libs: ["fdk-aac"]
       ]
     ]

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -8,6 +8,9 @@ static const MAX_AAC_BUFFER_SIZE = 8192;  // TODO: Validate
  * Heavily inspired by https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libfdk-aacenc.c
  */
 
+/**
+ * Returns a string description for the error code.
+ */
 char *get_error_message(AACENC_ERROR err) {
   switch (err) {
     case AACENC_OK:
@@ -39,6 +42,13 @@ char *get_error_message(AACENC_ERROR err) {
   }
 }
 
+/**
+ * Initializes AAC Encoder and returns State resource.
+ * 
+ * On success, returns {:ok, encoder_state}
+ * In case of error, returns:
+ * - {:error, reason}
+ */
 UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot) {
   State *state = unifex_alloc_state(env);
   state->channels = channels;
@@ -131,6 +141,19 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot) {
   return res;
 }
 
+/**
+ * Encodes one input frame.
+ * 
+ * Expects:
+ * - Buffer to encoder
+ * - Native resource
+ * as arguments
+ * 
+ * Returns on of:
+ * - {:ok, {encoded_frame}} - Encoded AAC frame
+ * - {:error, :no_data} - When supplied input buffer does not contain enough data to encode a single frame
+ * - {:error, reason} - When native encoding failed
+ */
 UNIFEX_TERM encode_frame(UnifexEnv *env, UnifexPayload *in_payload, State *state) {
   UNIFEX_TERM res;
   AACENC_ERROR err;

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -3,6 +3,10 @@
 static const int SAMPLE_SIZE = 2;
 static const int MAX_AAC_BUFFER_SIZE = 8192;  // TODO: Validate
 
+static const int PROFILE_AAC_HE = 5;
+static const int PROFILE_AAC_HE_v2 = 29;
+static const int PROFILE_MPEG2_AAC_HE = 132;
+
 /**
  * AAC Encoder implementation.
  * Heavily inspired by https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libfdk-aacenc.c
@@ -135,6 +139,12 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot, int b
   } else {
     // CBR
     int bitrate = (96 * sce + 128 * cpe) * sample_rate / 44;
+    if (aot == PROFILE_AAC_HE ||
+        aot == PROFILE_AAC_HE_v2 ||
+        aot == PROFILE_MPEG2_AAC_HE) {
+      bitrate /= 2;
+    }
+    printf("Calculated bitrate: %d\n", bitrate);
     err = aacEncoder_SetParam(state->handle, AACENC_BITRATE, bitrate);
     if (err != AACENC_OK) {
       MEMBRANE_WARN(env, "AAC: Unable to set bitrate: %x\n", err);

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -46,6 +46,7 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot) {
   AACENC_ERROR err;
   CHANNEL_MODE channel_mode;
   AACENC_InfoStruct info = {0};
+  // See: https://wiki.multimedia.cx/index.php/Understanding_AAC#Frames_And_Syntax_Elements
   int sce = 0, cpe = 0;
 
   // Initialize AAC Encoder handle

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -59,7 +59,7 @@ char *get_error_message(AACENC_ERROR err) {
  * In case of error, returns:
  * - {:error, reason}
  */
-UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot, int bitrate_mode) {
+UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot, int bitrate_mode, int bitrate) {
   State *state = unifex_alloc_state(env);
   state->channels = channels;
 
@@ -138,8 +138,12 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot, int b
     }
   } else {
     // CBR
+    // If bitrate is not specified by the user, this will estimate the bitrate, following the "rule of thumb"
+    // described here: https://trac.ffmpeg.org/wiki/Encode/AAC#fdk_cbr
     // This is based on: https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libfdk-aacenc.c#L245
-    int bitrate = (96 * sce + 128 * cpe) * sample_rate / 44;
+    if (!bitrate) {
+      bitrate = (96 * sce + 128 * cpe) * sample_rate / 44;
+    }
     if (aot == PROFILE_AAC_HE ||
         aot == PROFILE_AAC_HE_v2 ||
         aot == PROFILE_MPEG2_AAC_HE) {

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -55,7 +55,6 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot) {
 
   AACENC_ERROR err;
   CHANNEL_MODE channel_mode;
-  AACENC_InfoStruct info = {0};
   // See: https://wiki.multimedia.cx/index.php/Understanding_AAC#Frames_And_Syntax_Elements
   int sce = 0, cpe = 0;
 

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -1,0 +1,171 @@
+#include "encoder.h"
+
+static const int SAMPLE_SIZE = 4;
+static const MAX_AAC_BUFFER_SIZE = 8192;  // TODO: Validate
+
+/**
+ * AAC Encoder implementation.
+ * Heavily inspired by https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libfdk-aacenc.c
+ */
+
+char *get_error_message(AACENC_ERROR err) {
+  switch (err) {
+    case AACENC_OK:
+      return "No error";
+    case AACENC_INVALID_HANDLE:
+      return "Invalid handle";
+    case AACENC_MEMORY_ERROR:
+      return "Memory allocation error";
+    case AACENC_UNSUPPORTED_PARAMETER:
+      return "Unsupported parameter";
+    case AACENC_INVALID_CONFIG:
+      return "Invalid config";
+    case AACENC_INIT_ERROR:
+      return "Initialization error";
+    case AACENC_INIT_AAC_ERROR:
+      return "AAC library initialization error";
+    case AACENC_INIT_SBR_ERROR:
+      return "SBR library initialization error";
+    case AACENC_INIT_TP_ERROR:
+      return "Transport library initialization error";
+    case AACENC_INIT_META_ERROR:
+      return "Metadata library initialization error";
+    case AACENC_ENCODE_ERROR:
+      return "Encoding error";
+    case AACENC_ENCODE_EOF:
+      return "End of file";
+    default:
+      return "Unknown error";
+  }
+}
+
+UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot) {
+  State *state = unifex_alloc_state(env);
+  state->channels = channels;
+
+  AACENC_ERROR err;
+  CHANNEL_MODE channel_mode;
+
+  // Initialize AAC Encoder handle
+  err = aacEncOpen(&state->handle, 0, channels);
+  if (err != AACENC_OK) {
+    MEMBRANE_WARN(env, "AAC: Could not initialize encoder: %x\n", err);
+    return create_result_error(env, get_error_message(err));
+  }
+
+  // Set Audio Object Type
+  err = aacEncoder_SetParam(state->handle, AACENC_AOT, aot);
+  if (err != AACENC_OK) {
+    MEMBRANE_WARN(env, "AAC: Unable to set the AOT: %x\n", err);
+    return create_result_error(env, get_error_message(err));
+  }
+
+  // Set sample rate
+  err = aacEncoder_SetParam(state->handle, AACENC_SAMPLERATE, sample_rate);
+  if (err != AACENC_OK) {
+    MEMBRANE_WARN(env, "AAC: Unable to set sample rate: %x\n", err);
+    return create_result_error(env, get_error_message(err));
+  }
+
+  // Set channels configuration
+  switch (channels) {
+    case 1:
+      channel_mode = MODE_1;
+      break;
+    case 2:
+      channel_mode = MODE_2;
+      break;
+    default:
+      MEMBRANE_WARN(env, "AAC: Unsupported number of channels: %d", channels);
+      return create_result_error(env, get_error_message(err));
+  }
+  err = aacEncoder_SetParam(state->handle, AACENC_CHANNELMODE, channel_mode);
+  if (err != AACENC_OK) {
+    MEMBRANE_WARN(env, "AAC: Unable to set channel mode %d: %x\n", channel_mode, err);
+    return create_result_error(env, get_error_message(err));
+  }
+
+  err = aacEncoder_SetParam(state->handle, AACENC_CHANNELORDER, 1);
+  if (err != AACENC_OK) {
+    MEMBRANE_WARN(env, "AAC: Unable to set channel order: %x\n", err);
+    return create_result_error(env, get_error_message(err));
+  }
+
+  state->aac_buffer = unifex_alloc(MAX_AAC_BUFFER_SIZE);
+  if (!state->aac_buffer) {
+    MEMBRANE_WARN(env, "AAC: Unable to initialize AAC buffer\n", err);
+    return create_result_error(env, "no_memory");
+  }
+
+  err = aacEncEncode(state->handle, NULL, NULL, NULL, NULL);
+  if (err != AACENC_OK) {
+    MEMBRANE_WARN(env, "AAC: Unable to initialize the encoder: %x\n", err);
+    return create_result_error(env, get_error_message(err));
+  }
+
+  UNIFEX_TERM res = create_result_ok(env, state);
+  unifex_release_state(env, state);
+  return res;
+}
+
+UNIFEX_TERM encode_frame(UnifexEnv *env, UnifexPayload *in_payload, State *state) {
+  UNIFEX_TERM res;
+  AACENC_ERROR err;
+
+  AACENC_BufDesc in_buf = {0}, out_buf = {0};
+  AACENC_InArgs in_args = {0};
+  AACENC_OutArgs out_args = {0};
+  int in_buffer_identifier = IN_AUDIO_DATA;
+  int in_buffer_size, in_buffer_element_size;
+  int out_buffer_identifier = OUT_BITSTREAM_DATA;
+  int out_buffer_size, out_buffer_element_size;
+  void *in_ptr;
+  void *out_ptr;
+  uint8_t dummy_buf[1];
+
+  /* Handle :end_of_stream and flush */
+  if (!in_payload->data) {
+    in_ptr = dummy_buf;
+    in_buffer_size = 0;
+
+    in_args.numInSamples = -1;
+  } else {
+    int number_of_samples = in_payload->size / (state->channels * SAMPLE_SIZE);
+
+    in_ptr = in_payload->data[0];
+    in_buffer_size = 2 * state->channels * number_of_samples;
+  }
+
+  in_buffer_element_size = 2;
+  in_buf.numBufs = 1;
+  in_buf.bufs = &in_ptr;
+  in_buf.bufferIdentifiers = &in_buffer_identifier;
+  in_buf.bufSizes = &in_buffer_size;
+  in_buf.bufElSizes = &in_buffer_element_size;
+
+  out_ptr = state->aac_buffer[0];
+  out_buffer_size = in_payload->size;
+  out_buffer_element_size = 1;
+  out_buf.numBufs = 1;
+  out_buf.bufs = &out_ptr;
+  out_buf.bufferIdentifiers = &out_buffer_identifier;
+  out_buf.bufSizes = &out_buffer_size;
+  out_buf.bufElSizes = &out_buffer_element_size;
+
+  err = aacEncEncode(state->handle, &in_buf, &out_buf, &in_args, &out_args);
+  if (err != AACENC_OK) {
+  }
+
+  UnifexPayload *out_payload = unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, out_buffer_size);
+  memcpy(out_payload->data, state->aac_buffer, out_buffer_size);
+  unifex_payload_release(out_payload);
+  res = encode_frame_result_ok(env, out_payload);
+  return res;
+}
+
+void handle_destroy_state(UnifexEnv *env, State *state) {
+  UNIFEX_UNUSED(env);
+  if (state->handle) {
+    aacEncClose(&state->handle);
+  }
+}

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -1,7 +1,7 @@
 #include "encoder.h"
 
 static const int SAMPLE_SIZE = 2;
-static const MAX_AAC_BUFFER_SIZE = 8192;  // TODO: Validate
+static const int MAX_AAC_BUFFER_SIZE = 8192;  // TODO: Validate
 
 /**
  * AAC Encoder implementation.

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -1,6 +1,6 @@
 #include "encoder.h"
 
-static const int SAMPLE_SIZE = 4;
+static const int SAMPLE_SIZE = 2;
 static const MAX_AAC_BUFFER_SIZE = 8192;  // TODO: Validate
 
 /**
@@ -158,6 +158,7 @@ UNIFEX_TERM encode_frame(UnifexEnv *env, UnifexPayload *in_payload, State *state
 
   /* Handle :end_of_stream and flush */
   if (!in_payload->data) {
+    printf("PAYLOAD flush");
     in_ptr = dummy_buf;
     in_buffer_size = 0;
 
@@ -168,13 +169,13 @@ UNIFEX_TERM encode_frame(UnifexEnv *env, UnifexPayload *in_payload, State *state
     printf("Number of samples: %d\n", number_of_samples);
 
     in_ptr = in_payload->data;
-    in_buffer_size = 2 * state->channels * number_of_samples;
+    in_buffer_size = SAMPLE_SIZE * state->channels * number_of_samples;
 
     in_args.numInSamples = state->channels * number_of_samples;
     printf("in_buffer_size: %d\n", in_buffer_size);
   }
 
-  in_buffer_element_size = 2;
+  in_buffer_element_size = SAMPLE_SIZE;
   in_buf.numBufs = 1;
   in_buf.bufs = &in_ptr;
   in_buf.bufferIdentifiers = &in_buffer_identifier;

--- a/c_src/membrane_element_aac/encoder.c
+++ b/c_src/membrane_element_aac/encoder.c
@@ -138,13 +138,13 @@ UNIFEX_TERM create(UnifexEnv *env, int channels, int sample_rate, int aot, int b
     }
   } else {
     // CBR
+    // This is based on: https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libfdk-aacenc.c#L245
     int bitrate = (96 * sce + 128 * cpe) * sample_rate / 44;
     if (aot == PROFILE_AAC_HE ||
         aot == PROFILE_AAC_HE_v2 ||
         aot == PROFILE_MPEG2_AAC_HE) {
       bitrate /= 2;
     }
-    printf("Calculated bitrate: %d\n", bitrate);
     err = aacEncoder_SetParam(state->handle, AACENC_BITRATE, bitrate);
     if (err != AACENC_OK) {
       MEMBRANE_WARN(env, "AAC: Unable to set bitrate: %x\n", err);

--- a/c_src/membrane_element_aac/encoder.h
+++ b/c_src/membrane_element_aac/encoder.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <fdk-aac/aacenc_lib.h>
+#include <membrane/membrane.h>
+#define MEMBRANE_LOG_TAG "Membrane.Element.AAC.EncoderNative"
+#include <membrane/log.h>
+
+typedef struct _EncoderState {
+  HANDLE_AACENCODER handle;
+  unsigned char *aac_buffer;
+  int channels;
+} UnifexNifState;
+
+typedef UnifexNifState State;
+
+#include "_generated/encoder.h"

--- a/c_src/membrane_element_aac/encoder.h
+++ b/c_src/membrane_element_aac/encoder.h
@@ -9,6 +9,7 @@ typedef struct _EncoderState {
   HANDLE_AACENCODER handle;
   unsigned char *aac_buffer;
   int channels;
+  int frame_size;
 } UnifexNifState;
 
 typedef UnifexNifState State;

--- a/c_src/membrane_element_aac/encoder.h
+++ b/c_src/membrane_element_aac/encoder.h
@@ -9,7 +9,6 @@ typedef struct _EncoderState {
   HANDLE_AACENCODER handle;
   unsigned char *aac_buffer;
   int channels;
-  int frame_size;
 } UnifexNifState;
 
 typedef UnifexNifState State;

--- a/c_src/membrane_element_aac/encoder.spec.exs
+++ b/c_src/membrane_element_aac/encoder.spec.exs
@@ -17,3 +17,4 @@ spec create(
 
 spec encode_frame(payload, state) :: {:ok :: label, payload}
   | {:error :: label, reason :: atom}
+  | {:error :: label, :no_data :: label}

--- a/c_src/membrane_element_aac/encoder.spec.exs
+++ b/c_src/membrane_element_aac/encoder.spec.exs
@@ -3,7 +3,8 @@ module Membrane.Element.AAC.Encoder.Native
 spec create(
   channels :: int,
   sample_rate :: int,
-  aot :: int
+  aot :: int,
+  bitrate_mode :: int
 ) :: {:ok :: label, state}
   | {:error :: label, reason :: atom}
 

--- a/c_src/membrane_element_aac/encoder.spec.exs
+++ b/c_src/membrane_element_aac/encoder.spec.exs
@@ -4,7 +4,8 @@ spec create(
   channels :: int,
   sample_rate :: int,
   aot :: int,
-  bitrate_mode :: int
+  bitrate_mode :: int,
+  bitrate :: int
 ) :: {:ok :: label, state}
   | {:error :: label, reason :: atom}
 

--- a/c_src/membrane_element_aac/encoder.spec.exs
+++ b/c_src/membrane_element_aac/encoder.spec.exs
@@ -1,13 +1,5 @@
 module Membrane.Element.AAC.Encoder.Native
 
-# aot - Audio object type. See: https://github.com/mstorsjo/fdk-aac/blob/master/libAACenc/include/aacenc_lib.h#L1280
-# - 2: MPEG-4 AAC Low Complexity.
-# - 5: MPEG-4 AAC Low Complexity with Spectral Band Replication (HE-AAC).
-# - 29: MPEG-4 AAC Low Complexity with Spectral Band Replication and Parametric Stereo (HE-AAC v2). This configuration can be used only with stereo input audio data.
-# - 23: MPEG-4 AAC Low-Delay.
-# - 39: MPEG-4 AAC Enhanced Low-Delay.
-# - 129: MPEG-2 AAC Low Complexity.
-# - 132: MPEG-2 AAC Low Complexity with Spectral Band Replication (HE-AAC).
 spec create(
   channels :: int,
   sample_rate :: int,

--- a/c_src/membrane_element_aac/encoder.spec.exs
+++ b/c_src/membrane_element_aac/encoder.spec.exs
@@ -1,0 +1,19 @@
+module Membrane.Element.AAC.Encoder.Native
+
+# aot - Audio object type. See: https://github.com/mstorsjo/fdk-aac/blob/master/libAACenc/include/aacenc_lib.h#L1280
+# - 2: MPEG-4 AAC Low Complexity.
+# - 5: MPEG-4 AAC Low Complexity with Spectral Band Replication (HE-AAC).
+# - 29: MPEG-4 AAC Low Complexity with Spectral Band Replication and Parametric Stereo (HE-AAC v2). This configuration can be used only with stereo input audio data.
+# - 23: MPEG-4 AAC Low-Delay.
+# - 39: MPEG-4 AAC Enhanced Low-Delay.
+# - 129: MPEG-2 AAC Low Complexity.
+# - 132: MPEG-2 AAC Low Complexity with Spectral Band Replication (HE-AAC).
+spec create(
+  channels :: int,
+  sample_rate :: int,
+  aot :: int
+) :: {:ok :: label, state}
+  | {:error :: label, reason :: atom}
+
+spec encode_frame(payload, state) :: {:ok :: label, payload}
+  | {:error :: label, reason :: atom}

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -66,6 +66,17 @@ defmodule Membrane.Element.AAC.Encoder do
                 spec: allowed_bitrate_modes(),
                 default: 0
               ],
+              bitrate: [
+                description: """
+                Bitrate in bits/s for CBR.
+                If set to nil (default value), the bitrate will be estimated based on the number of channels and sample rate.
+                See: https://trac.ffmpeg.org/wiki/Encode/AAC#fdk_cbr
+                Note that for VBR this parameter is ignored.
+                """,
+                type: :integer,
+                spec: pos_integer() | nil,
+                default: nil
+              ],
               input_caps: [
                 description: """
                 Caps for the input pad. If set to nil (default value),
@@ -114,7 +125,8 @@ defmodule Membrane.Element.AAC.Encoder do
              input_caps.channels,
              input_caps.sample_rate,
              state.aot,
-             state.bitrate_mode
+             state.bitrate_mode,
+             state.bitrate
            ) do
       {:ok, %{state | native: native, input_caps: input_caps}}
     else
@@ -145,7 +157,8 @@ defmodule Membrane.Element.AAC.Encoder do
              caps.channels,
              caps.sample_rate,
              state.aot,
-             state.bitrate_mode
+             state.bitrate_mode,
+             state.bitrate
            ) do
       {:ok, %{state | native: native, input_caps: caps}}
     else
@@ -236,7 +249,7 @@ defmodule Membrane.Element.AAC.Encoder do
     {:ok, {acc |> Enum.reverse(), bytes_used}}
   end
 
-  defp mk_native(channels, sample_rate, aot, bitrate_mode) do
+  defp mk_native(channels, sample_rate, aot, bitrate_mode, bitrate) do
     with {:ok, channels} <- validate_channels(channels),
          {:ok, sample_rate} <- validate_sample_rate(sample_rate),
          {:ok, aot} <- validate_aot(aot),
@@ -246,7 +259,8 @@ defmodule Membrane.Element.AAC.Encoder do
              channels,
              sample_rate,
              aot,
-             bitrate_mode
+             bitrate_mode,
+             bitrate || 0
            ) do
       {:ok, native}
     else

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -21,7 +21,7 @@ defmodule Membrane.Element.AAC.Encoder do
 
   def_input_pads input: [
                    demand_unit: :bytes,
-                   caps: {Raw, format: :s32le, sample_rate: @sample_rate, channels: @channels}
+                   caps: {Raw, format: :s16le, sample_rate: @sample_rate, channels: @channels}
                  ]
 
   @impl true

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -68,7 +68,8 @@ defmodule Membrane.Element.AAC.Encoder do
     %{native: native} = state
 
     with {:ok, encoded_frame} <- Native.encode_frame(data, native) do
-      {{:ok, buffer: {:output, %Buffer{payload: encoded_frame}}}, state}
+      buffer_actions = [buffer: {:output, %Buffer{payload: encoded_frame}}]
+      {{:ok, buffer_actions ++ [redemand: :output]}, state}
     else
       {:error, reason} -> {{:error, reason}, state}
     end

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -14,7 +14,6 @@ defmodule Membrane.Element.AAC.Encoder do
   use Membrane.Log, tags: :membrane_element_aac
 
   # AAC Constants
-  @aac_frame_size 1024
   @sample_size 2
 
   @default_channels 2
@@ -135,7 +134,7 @@ defmodule Membrane.Element.AAC.Encoder do
 
   @impl true
   def handle_demand(:output, bufs, :buffers, _ctx, state) do
-    {{:ok, demand: {:input, @aac_frame_size * bufs}}, state}
+    {{:ok, demand: {:input, aac_frame_size(state.aot) * bufs}}, state}
   end
 
   @impl true

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -79,7 +79,7 @@ defmodule Membrane.Element.AAC.Encoder do
   def handle_event(:input, %EndOfStream{}, _ctx, state) do
     %{native: native} = state
 
-    with {:ok, encoded_frame} <- Native.encode_frame(nil, native) do
+    with {:ok, encoded_frame} <- Native.encode_frame(<<>>, native) do
       buffer_actions = [buffer: {:output, %Buffer{payload: encoded_frame}}]
       actions = [event: {:output, %EndOfStream{}}, notify: {:end_of_stream, :input}]
       {{:ok, buffer_actions ++ actions}, state}

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -7,8 +7,13 @@ defmodule Membrane.Element.AAC.Encoder do
   alias __MODULE__.Native
   alias Membrane.Buffer
   alias Membrane.Caps.Audio.Raw
+  alias Membrane.Event.EndOfStream
 
   @channels 2
+  @sample_rate 44_100
+  @aac_frame_size 1024
+  # TODO: 2 is for AAC LC, Add handling different AOTs
+  @audio_object_type 2
 
   def_output_pads output: [
                     caps: :any
@@ -16,12 +21,12 @@ defmodule Membrane.Element.AAC.Encoder do
 
   def_input_pads input: [
                    demand_unit: :bytes,
-                   caps: {Raw, format: :s32le, sample_rate: 44_100, channels: @channels}
+                   caps: {Raw, format: :s32le, sample_rate: @sample_rate, channels: @channels}
                  ]
 
   @impl true
-  def handle_init(options) do
-    {:ok, %{native: nil, options: options}}
+  def handle_init(_) do
+    {:ok, %{native: nil}}
   end
 
   @impl true
@@ -29,8 +34,8 @@ defmodule Membrane.Element.AAC.Encoder do
     with {:ok, native} <-
            Native.create(
              @channels,
-             state.options.sample_rate,
-             2
+             @sample_rate,
+             @audio_object_type
            ) do
       {:ok, %{state | native: native}}
     else
@@ -49,8 +54,8 @@ defmodule Membrane.Element.AAC.Encoder do
   end
 
   @impl true
-  def handle_demand(:output, bufs, :buffers, _ctx, %{raw_frame_size: size} = state) do
-    {{:ok, demand: {:input, size * bufs}}, state}
+  def handle_demand(:output, bufs, :buffers, _ctx, state) do
+    {{:ok, demand: {:input, @aac_frame_size * bufs}}, state}
   end
 
   @impl true
@@ -62,10 +67,28 @@ defmodule Membrane.Element.AAC.Encoder do
   def handle_process(:input, %Buffer{payload: data}, _ctx, state) do
     %{native: native} = state
 
-    with {:ok, {encoded_bufs}} <- Native.encode_frame(native, data) do
-      {{:ok, buffer: {:output, encoded_bufs}}, state}
+    with {:ok, encoded_frame} <- Native.encode_frame(data, native) do
+      {{:ok, buffer: {:output, %Buffer{payload: encoded_frame}}}, state}
     else
       {:error, reason} -> {{:error, reason}, state}
     end
+  end
+
+  @impl true
+  def handle_event(:input, %EndOfStream{}, _ctx, state) do
+    %{native: native} = state
+
+    with {:ok, encoded_frame} <- Native.encode_frame(nil, native) do
+      buffer_actions = [buffer: {:output, %Buffer{payload: encoded_frame}}]
+      actions = [event: {:output, %EndOfStream{}}, notify: {:end_of_stream, :input}]
+      {{:ok, buffer_actions ++ actions}, state}
+    else
+      {:error, reason} ->
+        {{:error, reason}, state}
+    end
+  end
+
+  def handle_event(pad, event, ctx, state) do
+    super(pad, event, ctx, state)
   end
 end

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -22,7 +22,7 @@ defmodule Membrane.Element.AAC.Encoder do
   # MPEG-4 AAC Low Complexity
   @default_audio_object_type 2
   @list_type allowed_channels :: [1, 2]
-  @list_type allowed_aots :: [2, 5, 29, 23, 39, 129, 132]
+  @list_type allowed_aots :: [2, 5, 29, 129, 132]
   @list_type allowed_sample_rates :: [
                96000,
                88200,
@@ -50,8 +50,6 @@ defmodule Membrane.Element.AAC.Encoder do
                 2: MPEG-4 AAC Low Complexity.
                 5: MPEG-4 AAC Low Complexity with Spectral Band Replication (HE-AAC).
                 29: MPEG-4 AAC Low Complexity with Spectral Band Replication and Parametric Stereo (HE-AAC v2). This configuration can be used only with stereo input audio data.
-                23: MPEG-4 AAC Low-Delay.
-                39: MPEG-4 AAC Enhanced Low-Delay.
                 129: MPEG-2 AAC Low Complexity.
                 132: MPEG-2 AAC Low Complexity with Spectral Band Replication (HE-AAC).
                 """,

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -1,0 +1,71 @@
+defmodule Membrane.Element.AAC.Encoder do
+  @moduledoc """
+  Element encoding raw audio into AAC format
+  """
+
+  use Membrane.Element.Base.Filter
+  alias __MODULE__.Native
+  alias Membrane.Buffer
+  alias Membrane.Caps.Audio.Raw
+
+  @channels 2
+
+  def_output_pads output: [
+                    caps: :any
+                  ]
+
+  def_input_pads input: [
+                   demand_unit: :bytes,
+                   caps: {Raw, format: :s32le, sample_rate: 44_100, channels: @channels}
+                 ]
+
+  @impl true
+  def handle_init(options) do
+    {:ok, %{native: nil, options: options}}
+  end
+
+  @impl true
+  def handle_stopped_to_prepared(_ctx, state) do
+    with {:ok, native} <-
+           Native.create(
+             @channels,
+             state.options.sample_rate,
+             2
+           ) do
+      {:ok, %{state | native: native}}
+    else
+      {:error, reason} -> {{:error, reason}, state}
+    end
+  end
+
+  @impl true
+  def handle_prepared_to_stopped(_ctx, state) do
+    {:ok, %{state | native: nil}}
+  end
+
+  @impl true
+  def handle_demand(:output, size, :bytes, _ctx, state) do
+    {{:ok, demand: {:input, size}}, state}
+  end
+
+  @impl true
+  def handle_demand(:output, bufs, :buffers, _ctx, %{raw_frame_size: size} = state) do
+    {{:ok, demand: {:input, size * bufs}}, state}
+  end
+
+  @impl true
+  def handle_caps(:input, _caps, _ctx, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_process(:input, %Buffer{payload: data}, _ctx, state) do
+    %{native: native} = state
+
+    with {:ok, {encoded_bufs}} <- Native.encode_frame(native, data) do
+      {{:ok, buffer: {:output, encoded_bufs}}, state}
+    else
+      {:error, reason} -> {{:error, reason}, state}
+    end
+  end
+end

--- a/lib/membrane_element_aac/encoder.ex
+++ b/lib/membrane_element_aac/encoder.ex
@@ -133,7 +133,7 @@ defmodule Membrane.Element.AAC.Encoder do
 
   def handle_caps(:input, caps, _ctx, %{input_caps: stored_caps}) do
     raise """
-    Received caps #{inspect(caps)} are different then defined in options #{inspect(stored_caps)}.
+    Received caps #{inspect(caps)} are different than defined in options #{inspect(stored_caps)}.
     If you want to allow converter to accept different input caps dynamically, use `nil` as input_caps.
     """
   end

--- a/lib/membrane_element_aac/encoder_native.ex
+++ b/lib/membrane_element_aac/encoder_native.ex
@@ -1,0 +1,7 @@
+defmodule Membrane.Element.AAC.Encoder.Native do
+  @moduledoc """
+  Interface module for native AAC encoder.
+  """
+
+  use Unifex.Loader
+end


### PR DESCRIPTION
## Description
Adds AAC encoder implementation

## Technical details
Once again, this is based on the FFmpeg implementation - https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libfdk-aacenc.c
It does not handle processing the whole input yet, but it shouldn't throw a segfault either.

EDIT: It now encodes the whole input, however the output file is sped up ~2x and is ~2x longer than the original (where the second half is just silence)

## TODO
- [x] Make sure all buffers are properly encoded
- [x] Add more configuration options
- [x] Add docstrings
- [x] ~Add tests~ (will be done in a separate PR, see: #5)
- [ ] ~Add AAC Caps~ (we've decided to leave them as `:any` for now and think about unifying MPEG caps or creating a separate AAC caps format).